### PR TITLE
Fix npm install into docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ If DB\_URI is omitted a database started from docker will be used
 ## Running
 To start the server use
 ```
-docker-compose up --build
+docker-compose -f docker-compose.yml up --build
 ```
 
 To start the server with nodemon for development use
 ```
-DEBUG=true docker-compose up --build
+docker-compose up --build
 ```

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,7 @@
+version: "3.2"
+
+services:
+    web:
+        command: "true"
+        volumes:
+            - ./web:/www

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,5 @@ services:
             - db
         depends_on:
             - db
+        command: ""
         restart: on-failure
-        volumes:
-            - ./web:/www
-        command: "$DEBUG"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,10 +1,12 @@
 FROM node
 
+COPY . /www
+WORKDIR /www
+
 RUN npm install
 RUN npm install -g nodemon
 
 EXPOSE 80
-WORKDIR /www
 
 ENV PORT 80
 ENTRYPOINT ["./entrypoint.sh"]

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 if [[ $1 == "true" ]]; then
+    npm install
     nodemon bin/www
 else
     node bin/www


### PR DESCRIPTION
docker-compose now has separate configs for development and production
The production one will copy the files into the container and do `npm install`  when the container is built
The development one uses a volume so that nodemon works correctly. `npm install` will run every-time the container is started (otherwise it would need to be done manually, afaik)